### PR TITLE
add 96Boards DragonBoard410c

### DIFF
--- a/adafruit_platformdetect/__init__.py
+++ b/adafruit_platformdetect/__init__.py
@@ -55,6 +55,17 @@ class Detector:
 
         return None
 
+    def get_dt_compatible_field(self, field):
+        """
+        Search /proc/device-tree/compatible for a field and return True, if found,
+        otherwise False.
+        """
+        # Match a value like 'qcom,apq8016-sbc':
+        if field in open('/proc/device-tree/compatible').read():
+                 return True
+
+        return False
+
     def get_armbian_release_field(self, field):
         """
         Search /etc/armbian-release, if it exists, for a field and return its

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -38,6 +38,8 @@ RASPBERRY_PI_3B             = "RASPBERRY_PI_3B"
 RASPBERRY_PI_3B_PLUS        = "RASPBERRY_PI_3B_PLUS"
 RASPBERRY_PI_CM3            = "RASPBERRY_PI_CM3"
 RASPBERRY_PI_3A_PLUS        = "RASPBERRY_PI_3A_PLUS"
+
+_96BOARDS                   = "96BOARDS"
 # pylint: enable=bad-whitespace
 
 ANY_RASPBERRY_PI_2_OR_3 = (
@@ -156,6 +158,7 @@ class Board:
             board_id = FEATHER_M0_EXPRESS
         elif chip_id == ap_chip.STM32:
             board_id = PYBOARD
+        else board_id = self._is_96boards()
 
         return board_id
     # pylint: enable=invalid-name
@@ -201,6 +204,11 @@ class Board:
 
         return None
     # pylint: enable=no-self-use
+
+    def _is_96Boards(self):
+        if self.detector.get_dt_compatible_field("qcom,apq8016-sbc") or self.detector.get_dt_compatible_field("hisilicon,hi3660-hikey960") or self.detector.get_dt_compatible_field("hisilicon,hi6220-hikey"):
+            return _96BOARDS
+        return None
 
     def _armbian_id(self):
         """Check whether the current board is an OrangePi PC."""

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -7,6 +7,7 @@ ESP8266 = "ESP8266"
 SAMD21 = "SAMD21"
 STM32 = "STM32"
 SUN8I = "SUN8I"
+APQ8016 = "APQ8016"
 GENERIC_X86 = "GENERIC_X86"
 
 class Chip:
@@ -36,10 +37,14 @@ class Chip:
 
         hardware = self.detector.get_cpuinfo_field("Hardware")
 
+        if self.detector.get_dt_compatible_field("qcom,apq8016"):
+            linux_id = APQ8016
+            return linux_id
+
         if hardware is None:
-            vendor_id = self.detector.get_cpuinfo_field("vendor_id")
-            if vendor_id in ("GenuineIntel", "AuthenticAMD"):
-                linux_id = GENERIC_X86
+            if vendor_id == self.detector.get_cpuinfo_field("vendor_id"):
+                if vendor_id in ("GenuineIntel", "AuthenticAMD"):
+                   linux_id = GENERIC_X86
         elif hardware in ("BCM2708", "BCM2708", "BCM2835"):
             linux_id = BCM2XXX
         elif "AM33XX" in hardware:


### PR DESCRIPTION
- We use /proc/device-tree/compatible and /proc/device-tree/model
to detect chip and board
- created get_dt_compatible_field to read said file and compare string
- added dragonboard410c as an example

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>