### PR TITLE
Proposal for ODROID C1/C2 support

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -39,6 +39,10 @@ RASPBERRY_PI_3B             = "RASPBERRY_PI_3B"
 RASPBERRY_PI_3B_PLUS        = "RASPBERRY_PI_3B_PLUS"
 RASPBERRY_PI_CM3            = "RASPBERRY_PI_CM3"
 RASPBERRY_PI_3A_PLUS        = "RASPBERRY_PI_3A_PLUS"
+
+ODROID_C1                   = "ODROID_C1"
+ODROID_C1_PLUS              = "ODROID_C1_PLUS"
+ODROID_C2                   = "ODROID_C2"
 # pylint: enable=bad-whitespace
 
 _RASPBERRY_PI_40_PIN_IDS = (
@@ -50,6 +54,12 @@ _RASPBERRY_PI_40_PIN_IDS = (
     RASPBERRY_PI_3B,
     RASPBERRY_PI_3B_PLUS,
     RASPBERRY_PI_3A_PLUS
+)
+
+_ODROID_40_PIN_IDS = (
+    ODROID_C1,
+    ODROID_C1_PLUS,
+    ODROID_C2
 )
 
 _BEAGLEBONE_IDS = (
@@ -181,6 +191,10 @@ class Board:
             board_id = FEATHER_M0_EXPRESS
         elif chip_id == ap_chip.STM32:
             board_id = PYBOARD
+        elif chip_id == ap_chip.S805:
+            board_id = ODROID_C1
+        elif chip_id == ap_chip.S905:
+            board_id = ODROID_C2
 
         return board_id
     # pylint: enable=invalid-name

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -7,6 +7,8 @@ ESP8266 = "ESP8266"
 SAMD21 = "SAMD21"
 STM32 = "STM32"
 SUN8I = "SUN8I"
+S805 = "S805"
+S905 = "S905"
 GENERIC_X86 = "GENERIC_X86"
 
 class Chip:
@@ -46,6 +48,10 @@ class Chip:
             linux_id = AM33XX
         elif "sun8i" in hardware:
             linux_id = SUN8I
+        elif "ODROIDC" in hardware:
+            linux_id = S805
+        elif "ODROID-C2" in hardware:
+            linux_id = S905
 
         return linux_id
 


### PR DESCRIPTION
I haven't figured out a way to distinguish between C1 and C1+ but pinout wise it shouldn't matter.
This is a proposal of how to detect these platforms; I tested on C1 and C2 for now. Both running Linux.