### PR TITLE
Improved Odroid C2 Detection

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -403,6 +403,11 @@ class Board:
         return self.GIANT_BOARD
 
     @property
+    def any_odroid_40_pin(self):
+        """Check whether the current board is any defined 40-pin Odroid."""
+        return self.id in _ODROID_40_PIN_IDS
+
+    @property
     def any_jetson_board(self):
         """Check whether the current board is any defined Jetson Board."""
         return self.id in _JETSON_IDS
@@ -412,7 +417,7 @@ class Board:
         """Check whether the current board is any embedded Linux device."""
         return self.any_raspberry_pi or self.any_beaglebone or \
          self.any_orange_pi or self.any_giant_board or self.any_jetson_board or \
-         self.any_coral_board
+         self.any_coral_board or self.any_odroid_40_pin
 
     def __getattr__(self, attr):
         """

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -92,6 +92,8 @@ class Chip:
                     linux_id = T194
             if compatible and 'imx8m' in compatible:
                 linux_id = IMX8MX
+            if compatible and 'odroid-c2' in compatible:
+                linux_id = S905
 
         elif hardware in ("BCM2708", "BCM2709", "BCM2835"):
             linux_id = BCM2XXX

--- a/bin/detect.py
+++ b/bin/detect.py
@@ -11,7 +11,6 @@ print("Board id: ", detector.board.id)
 print("Is this a Pi 3B+?", detector.board.RASPBERRY_PI_3B_PLUS)
 print("Is this a 40-pin Raspberry Pi?", detector.board.any_raspberry_pi_40_pin)
 print("Is this a BBB?", detector.board.BEAGLEBONE_BLACK)
-print("Is this an Orange Pi PC?", detector.board.ORANGE_PI_PC)
 print("Is this a Giant Board?", detector.board.GIANT_BOARD)
 print("Is this a Coral Edge TPU?", detector.board.CORAL_EDGE_TPU_DEV)
 print("Is this an embedded Linux system?", detector.board.any_embedded_linux)
@@ -22,3 +21,9 @@ if detector.board.any_raspberry_pi:
 
 if detector.board.any_jetson_board:
     print("Jetson platform detected.")
+
+if detector.board.any_orange_pi:
+    print("Orange Pi detected.")
+
+if detector.board.any_odroid_40_pin:
+    print("Odroid detected.")


### PR DESCRIPTION
On my Odroid with the latest Armbian Stretch, there was no Hardware tag under `cat /proc/cpuinfo`, but using `/proc/device-tree/compatible` worked.