### PR TITLE
 Updated 96 Boards detection to be more specific

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -382,6 +382,7 @@ class Board:
 
     @property
     def any_96boards(self):
+        """Check whether the current board is any 96boards board."""
         return self.id in _LINARO_96BOARDS_IDS
 
     @property

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -58,7 +58,7 @@ ODROID_C1_PLUS              = "ODROID_C1_PLUS"
 ODROID_C2                   = "ODROID_C2"
 
 FTDI_FT232H                 = "FT232H"
-LINARO_96BOARDS             = "LINARO_96BOARDS"
+DRAGONBOARD_410C            = "DRAGONBOARD_410C"
 # pylint: enable=bad-whitespace
 
 #OrangePI
@@ -111,6 +111,10 @@ _BEAGLEBONE_IDS = (
     BEAGLELOGIC_STANDALONE,
     OSD3358_DEV_BOARD,
     OSD3358_SM_RED,
+)
+
+_LINARO_96BOARDS_IDS = (
+    DRAGONBOARD_410C,
 )
 
 # BeagleBone eeprom board ids from:
@@ -291,7 +295,7 @@ class Board:
         elif chip_id == ap_chip.FT232H:
             board_id = FTDI_FT232H
         elif chip_id == ap_chip.APQ8016:
-            board_id = LINARO_96BOARDS
+            board_id = DRAGONBOARD_410C
         elif chip_id in (ap_chip.T210, ap_chip.T186, ap_chip.T194):
             board_id = self._tegra_id()
         return board_id
@@ -378,12 +382,7 @@ class Board:
 
     @property
     def any_96boards(self):
-        """Check if the current board is any 96Boards-family board."""
-        return (
-            self.detector.check_dt_compatible_value("qcom,apq8016-sbc")
-            or self.detector.check_dt_compatible_value("hisilicon,hi3660-hikey960")
-            or self.detector.check_dt_compatible_value("hisilicon,hi6220-hikey")
-            )
+        return self.id in _LINARO_96BOARDS_IDS
 
     @property
     def any_raspberry_pi(self):

--- a/bin/detect.py
+++ b/bin/detect.py
@@ -8,7 +8,7 @@ print("Chip id: ", detector.chip.id)
 
 print("Board id: ", detector.board.id)
 
-print("Is this a 96Boards board?", detector.board.LINARO_96BOARDS)
+print("Is this a DragonBoard 410c?", detector.board.DRAGONBOARD_410C)
 print("Is this a Pi 3B+?", detector.board.RASPBERRY_PI_3B_PLUS)
 print("Is this a 40-pin Raspberry Pi?", detector.board.any_raspberry_pi_40_pin)
 print("Is this a BBB?", detector.board.BEAGLEBONE_BLACK)


### PR DESCRIPTION
When trying to make a specific board for the Dragonboard 410c, I realized this was returning too generic of a value. This updates it return exactly what I need. Also, it's now more in line with the way we're doing the other boards.