### PR TITLE
Initial support for Sifive's HiFive Unleashed

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -61,7 +61,7 @@ ODROID_C2                   = "ODROID_C2"
 FTDI_FT232H                 = "FT232H"
 DRAGONBOARD_410C            = "DRAGONBOARD_410C"
 
-SIFIVEHFUA00                = "SIFIVEHFUA00"
+SIFIVE_UNLEASHED                = "SIFIVE_UNLEASHED"
 
 # pylint: enable=bad-whitespace
 
@@ -124,7 +124,7 @@ _LINARO_96BOARDS_IDS = (
 
 
 _SIFIVE_IDS = (
-    SIFIVEHFUA00,
+    SIFIVE_UNLEASHED,
 )
 
 # BeagleBone eeprom board ids from:
@@ -401,7 +401,8 @@ class Board:
         """Try to detect the id for Sifive RISCV64 board."""
         board_value = self.detector.get_device_model()
         if 'hifive-unleashed-a00' in board_value:
-            return SIFIVEHFUA00
+            return SIFIVE_UNLEASHED
+	return None
 
     @property
     def any_96boards(self):

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -402,7 +402,7 @@ class Board:
         board_value = self.detector.get_device_model()
         if 'hifive-unleashed-a00' in board_value:
             return SIFIVE_UNLEASHED
-	return None
+        return None
 
     @property
     def any_96boards(self):

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -60,6 +60,9 @@ ODROID_C2                   = "ODROID_C2"
 
 FTDI_FT232H                 = "FT232H"
 DRAGONBOARD_410C            = "DRAGONBOARD_410C"
+
+SIFIVEHFUA00                = "SIFIVEHFUA00"
+
 # pylint: enable=bad-whitespace
 
 #OrangePI
@@ -117,6 +120,11 @@ _BEAGLEBONE_IDS = (
 
 _LINARO_96BOARDS_IDS = (
     DRAGONBOARD_410C,
+)
+
+
+_SIFIVE_IDS = (
+    SIFIVEHFUA00,
 )
 
 # BeagleBone eeprom board ids from:
@@ -305,6 +313,8 @@ class Board:
             board_id = DRAGONBOARD_410C
         elif chip_id in (ap_chip.T210, ap_chip.T186, ap_chip.T194):
             board_id = self._tegra_id()
+        elif chip_id == ap_chip.HFU540:
+            board_id = self._sifive_id()
         return board_id
     # pylint: enable=invalid-name
 
@@ -387,6 +397,12 @@ class Board:
             board = JETSON_NANO
         return board
 
+    def _sifive_id(self):
+        """Try to detect the id for Sifive RISCV64 board."""
+        board_value = self.detector.get_device_model()
+        if 'hifive-unleashed-a00' in board_value:
+            return SIFIVEHFUA00
+
     @property
     def any_96boards(self):
         """Check whether the current board is any 96boards board."""
@@ -433,11 +449,17 @@ class Board:
         return self.id in _JETSON_IDS
 
     @property
+    def any_sifive_board(self):
+        """Check whether the current board is any defined Jetson Board."""
+        return self.id in _SIFIVE_IDS
+
+    @property
     def any_embedded_linux(self):
         """Check whether the current board is any embedded Linux device."""
         return self.any_raspberry_pi or self.any_beaglebone or \
          self.any_orange_pi or self.any_giant_board or self.any_jetson_board or \
-         self.any_coral_board or self.any_odroid_40_pin or self.any_96boards
+         self.any_coral_board or self.any_odroid_40_pin or self.any_96boards or \
+         self.any_sifive_board
 
     def __getattr__(self, attr):
         """

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -18,6 +18,7 @@ T194 = "T194"
 APQ8016 = "APQ8016"
 GENERIC_X86 = "GENERIC_X86"
 FT232H = "FT232H"
+HFU540 = "HFU540"
 
 class Chip:
     """Attempt detection of current chip / CPU."""
@@ -77,6 +78,9 @@ class Chip:
 
         if self.detector.check_dt_compatible_value("qcom,apq8016"):
             return APQ8016
+
+        if self.detector.check_dt_compatible_value("fu500"):
+            return HFU540
 
         linux_id = None
         hardware = self.detector.get_cpuinfo_field("Hardware")

--- a/bin/detect.py
+++ b/bin/detect.py
@@ -15,6 +15,7 @@ print("Is this a 40-pin Raspberry Pi?", detector.board.any_raspberry_pi_40_pin)
 print("Is this a BBB?", detector.board.BEAGLEBONE_BLACK)
 print("Is this a Giant Board?", detector.board.GIANT_BOARD)
 print("Is this a Coral Edge TPU?", detector.board.CORAL_EDGE_TPU_DEV)
+print("Is this a SiFive Unleashed? ", detector.board.SIFIVE_UNLEASHED)
 print("Is this an embedded Linux system?", detector.board.any_embedded_linux)
 print("Is this a generic Linux PC?", detector.board.GENERIC_LINUX_PC)
 


### PR DESCRIPTION
Board family detection still missing. Chip and board are fine.

From test code:
('Chip id: ', 'HFU540')
('Board id: ', 'SIFIVEHFUA00')
('Sifive? ', False)

Should be true.