### PR TITLE
Fixing Jetson Nano detection

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -405,7 +405,7 @@ class Board:
             board = JETSON_TX2
         elif 'xavier' in board_value:
             board = JETSON_XAVIER
-        elif 'nano' in board_value:
+        elif 'nano' in board_value or "Nano" in board_value:
             board = JETSON_NANO
         return board
 


### PR DESCRIPTION
Hello,

Seems like this is not working properly anymore in board.py (_tegra_id): 

`elif 'nano' in board_value:
            board = JETSON_NANO`

In /proc/device-tree/model of my jetson nano, I see:
NVIDIA Jetson **Nano** Developer Kit

I checked a previous install on another sd card and the file read : 
jetson **nano**

I think the function should now look for nano or Nano.

Thanks