### PR TITLE
 Update board.py for nvidia Jetson boards

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -403,13 +403,13 @@ class Board:
         """Try to detect the id of aarch64 board."""
         board_value = self.detector.get_device_model()
         board = None
-        if 'tx1' in board_value:
+        if 'tx1' in board_value.lower():
             board = JETSON_TX1
-        elif 'quill' in board_value:
+        elif 'quill' in board_value or "storm" in board_value or "lightning" in board_value:
             board = JETSON_TX2
-        elif 'xavier' in board_value:
+        elif 'xavier' in board_value.lower():
             board = JETSON_XAVIER
-        elif 'nano' in board_value or "Nano" in board_value:
+        elif 'nano' in board_value.lower():
             board = JETSON_NANO
         return board
 


### PR DESCRIPTION
Recently, Model names are updated for Jetson Nvidia boards.
This change takes care of model name check of Jetson TX1 nano and Xavier. Change also adds support for
Quill derivatives like storm and lightning.