### PR TITLE
RFC: Attempt To Recognize Raspberry Pi Running Non-Raspbian OS

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -1,5 +1,6 @@
 """Detect boards."""
 import os
+import re
 import adafruit_platformdetect.chip as ap_chip
 
 # Allow for aligned constant definitions:
@@ -367,6 +368,30 @@ class Board:
             for model, codes in _PI_REV_CODES.items():
                 if pi_rev_code in codes:
                     return model
+
+        # We may be on a non-Raspbian OS, so try to lazily determine
+        # the version based on `get_device_model`
+        else:
+            pi_model = self.detector.get_device_model()
+            if pi_model:
+                pi_model = pi_model.upper().replace(' ', '_')
+                if "PLUS" in pi_model:
+                    re_model = re.search(r'(RASPBERRY_PI_\d).*([AB]_*)(PLUS)',
+                                         pi_model)
+                elif "CM" in pi_model: # untested for Compute Module
+                    re_model = re.search(r'(RASPBERRY_PI_CM)(\d)',
+                                         pi_model)
+                else: # untested for non-plus models
+                    re_model = re.search(r'(RASPBERRY_PI_\d).*([AB]_*)',
+                                         pi_model)
+
+                if re_model:
+                    pi_model = "".join(re_model.groups())
+                    available_models = _PI_REV_CODES.keys()
+                    for model in available_models:
+                        if model == pi_model:
+                            return model
+
         return None
 
     def _pi_rev_code(self):

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -23,6 +23,9 @@ HFU540 = "HFU540"
 MCP2221 = "MCP2221"
 BINHO = "BINHO"
 
+BCM_RANGE = {'BCM2708', 'BCM2709', 'BCM2835', 'BCM2837', 'bcm2708', 'bcm2709',
+             'bcm2835', 'bcm2837'}
+
 class Chip:
     """Attempt detection of current chip / CPU."""
     def __init__(self, detector):

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -106,9 +106,7 @@ class Chip:
                 ]
 
         if not linux_id:
-            if set(hardware) & BCM_RANGE:
-                linux_id = BCM2XXX
-            elif 'AM33XX' in hardware:
+            if 'AM33XX' in hardware:
                 linux_id = AM33XX
             elif 'sun8i' in hardware:
                 linux_id = SUN8I
@@ -120,6 +118,13 @@ class Chip:
                 linux_id = S922X
             elif 'SAMA5' in hardware:
                 linux_id = SAMA5
+            else:
+                if isinstance(hardware, str):
+                    if hardware in BCM_RANGE:
+                        linux_id = BCM2XXX
+                elif instance(hardware, list):
+                    if set(hardware) & BCM_RANGE:
+                        linux_id = BCM2XXX
 
         return linux_id
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -102,7 +102,7 @@ class Chip:
             # conditions attempt.
             if not linux_id:
                 hardware = [
-                    entry.replace("\x00", "") for entry in compatible.split(",")
+                    entry.replace('\x00', '') for entry in compatible.split(',')
                 ]
 
         if not linux_id:

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -115,20 +115,34 @@ class Chip:
                 elif "MIPS 24KEc" in cpu_model:
                     linux_id = MIPS24KEC
 
-        elif hardware in ("BCM2708", "BCM2709", "BCM2835"):
-            linux_id = BCM2XXX
-        elif "AM33XX" in hardware:
-            linux_id = AM33XX
-        elif "sun8i" in hardware:
-            linux_id = SUN8I
-        elif "ODROIDC" in hardware:
-            linux_id = S805
-        elif "ODROID-C2" in hardware:
-            linux_id = S905
-        elif "ODROID-N2" in hardware:
-            linux_id = S922X
-        elif "SAMA5" in hardware:
-            linux_id = SAMA5
+            # we still haven't identified the hardware, so
+            # convert it to a list and let the remaining
+            # conditions attempt.
+            if not linux_id:
+                hardware = [
+                    entry.replace('\x00', '') for entry in compatible.split(',')
+                ]
+
+        if not linux_id:
+            if 'AM33XX' in hardware:
+                linux_id = AM33XX
+            elif 'sun8i' in hardware:
+                linux_id = SUN8I
+            elif 'ODROIDC' in hardware:
+                linux_id = S805
+            elif 'ODROID-C2' in hardware:
+                linux_id = S905
+            elif 'ODROID-N2' in hardware:
+                linux_id = S922X
+            elif 'SAMA5' in hardware:
+                linux_id = SAMA5
+            else:
+                if isinstance(hardware, str):
+                    if hardware in BCM_RANGE:
+                        linux_id = BCM2XXX
+                elif isinstance(hardware, list):
+                    if set(hardware) & BCM_RANGE:
+                        linux_id = BCM2XXX
 
         return linux_id
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -2,24 +2,24 @@
 import sys
 import os
 
-AM33XX = "AM33XX"
-IMX8MX = "IMX8MX"
-BCM2XXX = "BCM2XXX"
-ESP8266 = "ESP8266"
-SAMD21 = "SAMD21"
-STM32 = "STM32"
-SUN8I = "SUN8I"
-S805 = "S805"
-S905 = "S905"
-S922X = "S922X"
-SAMA5 = "SAMA5"
-T210 = "T210"
-T186 = "T186"
-T194 = "T194"
-APQ8016 = "APQ8016"
-GENERIC_X86 = "GENERIC_X86"
-FT232H = "FT232H"
-HFU540 = "HFU540"
+AM33XX = 'AM33XX'
+IMX8MX = 'IMX8MX'
+BCM2XXX = 'BCM2XXX'
+ESP8266 = 'ESP8266'
+SAMD21 = 'SAMD21'
+STM32 = 'STM32'
+SUN8I = 'SUN8I'
+S805 = 'S805'
+S905 = 'S905'
+S922X = 'S922X'
+SAMA5 = 'SAMA5'
+T210 = 'T210'
+T186 = 'T186'
+T194 = 'T194'
+APQ8016 = 'APQ8016'
+GENERIC_X86 = 'GENERIC_X86'
+FT232H = 'FT232H'
+HFU540 = 'HFU540'
 
 class Chip:
     """Attempt detection of current chip / CPU."""
@@ -50,13 +50,13 @@ class Chip:
             pass
 
         platform = sys.platform
-        if platform == "linux" or platform == "linux2":
+        if platform in ('linux', 'linux2'):
             return self._linux_id()
-        if platform == "esp8266":
+        if platform == 'esp8266':
             return ESP8266
-        if platform == "samd21":
+        if platform == 'samd21':
             return SAMD21
-        if platform == "pyboard":
+        if platform == 'pyboard':
             return STM32
         # nothing found!
         return None
@@ -65,18 +65,18 @@ class Chip:
     def _linux_id(self): # pylint: disable=too-many-branches
         """Attempt to detect the CPU on a computer running the Linux kernel."""
 
-        if self.detector.check_dt_compatible_value("qcom,apq8016"):
+        if self.detector.check_dt_compatible_value('qcom,apq8016'):
             return APQ8016
 
-        if self.detector.check_dt_compatible_value("fu500"):
+        if self.detector.check_dt_compatible_value('fu500'):
             return HFU540
 
         linux_id = None
-        hardware = self.detector.get_cpuinfo_field("Hardware")
+        hardware = self.detector.get_cpuinfo_field('Hardware')
 
         if hardware is None:
-            vendor_id = self.detector.get_cpuinfo_field("vendor_id")
-            if vendor_id in ("GenuineIntel", "AuthenticAMD"):
+            vendor_id = self.detector.get_cpuinfo_field('vendor_id')
+            if vendor_id in ('GenuineIntel', 'AuthenticAMD'):
                 linux_id = GENERIC_X86
 
             compatible = self.detector.get_device_compatible()

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -21,6 +21,9 @@ GENERIC_X86 = 'GENERIC_X86'
 FT232H = 'FT232H'
 HFU540 = 'HFU540'
 
+BCM_RANGE = {'BCM2708', 'BCM2709', 'BCM2835', 'BCM2837', 'bcm2708', 'bcm2709',
+             'bcm2835', 'bcm2837'}
+
 class Chip:
     """Attempt detection of current chip / CPU."""
     def __init__(self, detector):
@@ -94,20 +97,29 @@ class Chip:
             if compatible and 'amlogic, g12b' in compatible:
                 linux_id = S922X
 
-        elif hardware in ("BCM2708", "BCM2709", "BCM2835"):
-            linux_id = BCM2XXX
-        elif "AM33XX" in hardware:
-            linux_id = AM33XX
-        elif "sun8i" in hardware:
-            linux_id = SUN8I
-        elif "ODROIDC" in hardware:
-            linux_id = S805
-        elif "ODROID-C2" in hardware:
-            linux_id = S905
-        elif "ODROID-N2" in hardware:
-            linux_id = S922X
-        elif "SAMA5" in hardware:
-            linux_id = SAMA5
+            # we still haven't identified the hardware, so
+            # convert it to a list and let the remaining
+            # conditions attempt.
+            if not linux_id:
+                hardware = [
+                    entry.replace("\x00", "") for entry in compatible.split(",")
+                ]
+
+        if not linux_id:
+            if set(hardware) & BCM_RANGE:
+                linux_id = BCM2XXX
+            elif 'AM33XX' in hardware:
+                linux_id = AM33XX
+            elif 'sun8i' in hardware:
+                linux_id = SUN8I
+            elif 'ODROIDC' in hardware:
+                linux_id = S805
+            elif 'ODROID-C2' in hardware:
+                linux_id = S905
+            elif 'ODROID-N2' in hardware:
+                linux_id = S922X
+            elif 'SAMA5' in hardware:
+                linux_id = SAMA5
 
         return linux_id
 


### PR DESCRIPTION
Addresses [Adafruit-Blinka issue 99](https://github.com/adafruit/Adafruit_Blinka/issues/99).

I'm currently running Ubuntu Server 19.04 on a Pi 3B+, which seems to produce the same results as the Arch user in the aforementioned issue. The `RPI.GPIO` issue seems to have been fixed, according to the linked issue/ticket.

Output examples:
```
(.env) rosie@rosiepi:~/plat_detect/Adafruit_Python_PlatformDetect$ uname -a
Linux rosiepi 5.0.0-1020-raspi2 #20-Ubuntu SMP Wed Oct 2 07:03:12 UTC 2019 aarch64 aarch64 aarch64 GNU/Linux

(.env) rosie@rosiepi:~/plat_detect/Adafruit_Python_PlatformDetect$ cat /proc/device-tree/model
Raspberry Pi 3 Model B Plus Rev 1.3

(.env) rosie@rosiepi:~/plat_detect/Adafruit_Python_PlatformDetect$ python3
Python 3.7.3 (default, Oct  7 2019, 12:56:13) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from adafruit_platformdetect import Detector
>>> foo = Detector()           
>>> foo.chip.id 
'BCM2XXX'
>>> foo.board.id
'RASPBERRY_PI_3B_PLUS'
>>> 

(.env) rosie@rosiepi:~/plat_detect/Adafruit_Python_PlatformDetect$ python3 -m bin.detect
Chip id:  BCM2XXX
Board id:  RASPBERRY_PI_3B_PLUS
Is this a DragonBoard 410c? False
Is this a Pi 3B+? True
Is this a Pi 4B? False
Is this a 40-pin Raspberry Pi? True
Is this a Raspberry Pi Compute Module? False
Is this a BBB? False
Is this a Giant Board? False
Is this a Coral Edge TPU? False
Is this a SiFive Unleashed?  False
Is this an embedded Linux system? False
Is this a generic Linux PC? False
```
I haven't tested this on any other board, nor with Raspbian or any other distro. 

Also, attempts so far to test with Adafruit-Blinka have failed. `rpi-ws281x` has build issues on aarch64/arm64 (same as this issue: https://github.com/rpi-ws281x/rpi-ws281x-python/issues/26, but with all versions).