### PR TITLE
Initial addition for Pine64 devices

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -367,7 +367,7 @@ class Board:
             board_id = ONION_OMEGA
         elif chip_id == ap_chip.MIPS24KEC:
             board_id = ONION_OMEGA2
-        elif chip_id == ap_chip.SUN50IW1P1:
+        elif chip_id == ap_chip.PINE64:
             board_id = self._pine64_id()
         return board_id
     # pylint: enable=invalid-name
@@ -423,6 +423,8 @@ class Board:
             return ORANGE_PI_R1
         if board_value == "orangepizero":
             return ORANGE_PI_ZERO
+        if board_value == "pinebook-a64":
+            return PINEBOOK
         return None
 
     def _sama5_id(self):

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -534,7 +534,7 @@ class Board:
 
     @property
     def any_pine64_board(self):
-        """Check whether the current board is any defined OpenWRT board."""
+        """Check whether the current board is any Pine64 device."""
         return self.id in _PINE64_DEV_IDS
 
     @property

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -367,7 +367,7 @@ class Board:
             board_id = ONION_OMEGA
         elif chip_id == ap_chip.MIPS24KEC:
             board_id = ONION_OMEGA2
-        elif chip_id == ap_chip.PINE64:
+        elif chip_id == ap_chip.A64:
             board_id = self._pine64_id()
         return board_id
     # pylint: enable=invalid-name

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -73,6 +73,10 @@ BINHO_NOVA                  = "BINHO_NOVA"
 ONION_OMEGA                 = "ONION_OMEGA"
 ONION_OMEGA2                = "ONION_OMEGA2"
 
+PINE64 = "PINE64"
+PINEBOOK = "PINEBOOK"
+PINEPHONE = "PINEPHONE"
+
 # pylint: enable=bad-whitespace
 
 #OrangePI
@@ -297,6 +301,13 @@ _ONION_OMEGA_BOARD_IDS = (
     ONION_OMEGA2,
 )
 
+# Pine64 boards and devices
+_PINE64_DEV_IDS = (
+    PINE64,
+    PINEBOOK,
+    PINEPHONE
+)
+
 class Board:
     """Attempt to detect specific boards."""
     def __init__(self, detector):
@@ -356,6 +367,8 @@ class Board:
             board_id = ONION_OMEGA
         elif chip_id == ap_chip.MIPS24KEC:
             board_id = ONION_OMEGA2
+        elif chip_id == ap_chip.SUN50IW1P1:
+            board_id = self._pine64_id()
         return board_id
     # pylint: enable=invalid-name
 
@@ -447,6 +460,18 @@ class Board:
             return SIFIVE_UNLEASHED
         return None
 
+    def _pine64_id(self):
+        """Try to detect the id for Pine64 board or device."""
+        board_value = self.detector.get_device_model()
+        board = None
+        if 'pine64' in board_value.lower():
+            board = PINE64
+        elif 'pinebook' in board_value.lower():
+            board = PINEBOOK
+        elif 'pinephone' in board_value.lower():
+            board = PINEPHONE
+        return board
+
     @property
     def any_96boards(self):
         """Check whether the current board is any 96boards board."""
@@ -508,12 +533,17 @@ class Board:
         return self.id in _ONION_OMEGA_BOARD_IDS
 
     @property
+    def any_pine64_board(self):
+        """Check whether the current board is any defined OpenWRT board."""
+        return self.id in _PINE64_DEV_IDS
+
+    @property
     def any_embedded_linux(self):
         """Check whether the current board is any embedded Linux device."""
         return self.any_raspberry_pi or self.any_beaglebone or \
          self.any_orange_pi or self.any_giant_board or self.any_jetson_board or \
          self.any_coral_board or self.any_odroid_40_pin or self.any_96boards or \
-         self.any_sifive_board or self.any_onion_omega_board
+         self.any_sifive_board or self.any_onion_omega_board or self.any_pine64_board
 
     @property
     def ftdi_ft232h(self):

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -24,6 +24,7 @@ MCP2221 = "MCP2221"
 BINHO = "BINHO"
 MIPS24KC = "MIPS24KC"
 MIPS24KEC = "MIPS24KEC"
+SUN50IW1P1 = "SUN50IW1P1"
 
 class Chip:
     """Attempt detection of current chip / CPU."""
@@ -127,6 +128,8 @@ class Chip:
             linux_id = S922X
         elif "SAMA5" in hardware:
             linux_id = SAMA5
+        elif "A64" in hardware:
+            linux_id = SUN50IW1P1
 
         return linux_id
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -143,6 +143,8 @@ class Chip:
                 linux_id = SAMA5
             elif "Pinebook" in hardware:
                 linux_id = A64
+            elif "sun50iw1p1" in hardware:
+                linux_id = A64
             else:
                 if isinstance(hardware, str):
                     if hardware in BCM_RANGE:

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -24,7 +24,7 @@ MCP2221 = "MCP2221"
 BINHO = "BINHO"
 MIPS24KC = "MIPS24KC"
 MIPS24KEC = "MIPS24KEC"
-SUN50IW1P1 = "SUN50IW1P1"
+PINE64 = "PINE64"
 
 class Chip:
     """Attempt detection of current chip / CPU."""
@@ -128,8 +128,8 @@ class Chip:
             linux_id = S922X
         elif "SAMA5" in hardware:
             linux_id = SAMA5
-        elif "A64" in hardware:
-            linux_id = SUN50IW1P1
+        elif "Pinebook" in hardware:
+            linux_id = PINE64
 
         return linux_id
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -107,7 +107,7 @@ class Chip:
 
             cpu_model = self.detector.get_cpuinfo_field("cpu model")
 
-            if cpu_model:
+            if cpu_model is not None:
                 if "MIPS 24Kc" in cpu_model:
                     linux_id = MIPS24KC
                 elif "MIPS 24KEc" in cpu_model:

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -24,7 +24,7 @@ MCP2221 = "MCP2221"
 BINHO = "BINHO"
 MIPS24KC = "MIPS24KC"
 MIPS24KEC = "MIPS24KEC"
-PINE64 = "PINE64"
+A64 = "A64"
 
 class Chip:
     """Attempt detection of current chip / CPU."""
@@ -129,7 +129,7 @@ class Chip:
         elif "SAMA5" in hardware:
             linux_id = SAMA5
         elif "Pinebook" in hardware:
-            linux_id = PINE64
+            linux_id = A64
 
         return linux_id
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -80,7 +80,7 @@ class Chip:
 
     # pylint: enable=invalid-name
 
-    def _linux_id(self):  # pylint: disable=too-many-branches
+    def _linux_id(self):  # pylint: disable=too-many-branches,too-many-statements
         """Attempt to detect the CPU on a computer running the Linux kernel."""
 
         if self.detector.check_dt_compatible_value('qcom,apq8016'):

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -107,10 +107,11 @@ class Chip:
 
             cpu_model = self.detector.get_cpuinfo_field("cpu model")
 
-            if "MIPS 24Kc" in cpu_model:
-                linux_id = MIPS24KC
-            elif "MIPS 24KEc" in cpu_model:
-                linux_id = MIPS24KEC
+            if cpu_model:
+                if "MIPS 24Kc" in cpu_model:
+                    linux_id = MIPS24KC
+                elif "MIPS 24KEc" in cpu_model:
+                    linux_id = MIPS24KEC
 
         elif hardware in ("BCM2708", "BCM2709", "BCM2835"):
             linux_id = BCM2XXX

--- a/bin/detect.py
+++ b/bin/detect.py
@@ -19,8 +19,8 @@ print("Is this a Coral Edge TPU?", detector.board.CORAL_EDGE_TPU_DEV)
 print("Is this a SiFive Unleashed? ", detector.board.SIFIVE_UNLEASHED)
 print("Is this an embedded Linux system?", detector.board.any_embedded_linux)
 print("Is this a generic Linux PC?", detector.board.GENERIC_LINUX_PC)
-print("Is this an OS environment variable special case?", detector.board.FTDI_FT232H       |
-                                                          detector.board.MICROCHIP_MCP2221 )
+print("Is this an OS environment variable special case?", detector.board.FTDI_FT232H |
+      detector.board.MICROCHIP_MCP2221)
 
 if detector.board.any_raspberry_pi:
     print("Raspberry Pi detected.")
@@ -36,3 +36,6 @@ if detector.board.any_odroid_40_pin:
 
 if detector.board.any_onion_omega_board:
     print("Onion Omega detected.")
+
+if detector.board.any_pine64_board:
+    print("Pine64 device detected.")


### PR DESCRIPTION
I will need the output of the `/proc/cpuinfo` and the `/proc/device-tree/model` for a better implementation.