### PR TITLE
Add Orange Pi boards (One, Lite, PC +)

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -27,10 +27,15 @@ FEATHER_M0_EXPRESS          = "FEATHER_M0_EXPRESS"
 GENERIC_LINUX_PC            = "GENERIC_LINUX_PC"
 PYBOARD                     = "PYBOARD"
 NODEMCU                     = "NODEMCU"
+GIANT_BOARD                 = "GIANT_BOARD"
+
+# Orange Pi boards
 ORANGE_PI_PC                = "ORANGE_PI_PC"
 ORANGE_PI_R1                = "ORANGE_PI_R1"
 ORANGE_PI_ZERO              = "ORANGE_PI_ZERO"
-GIANT_BOARD                 = "GIANT_BOARD"
+ORANGE_PI_ONE               = "ORANGE_PI_ONE"
+ORANGE_PI_LITE              = "ORANGE_PI_LITE"
+ORANGE_PI_PC_PLUS           = "ORANGE_PI_PC_PLUS"
 
 # NVIDIA Jetson boards
 JETSON_TX1                  = 'JETSON_TX1'
@@ -85,7 +90,10 @@ PINEPHONE = "PINEPHONE"
 _ORANGE_PI_IDS = (
     ORANGE_PI_PC,
     ORANGE_PI_R1,
-    ORANGE_PI_ZERO
+    ORANGE_PI_ZERO,
+    ORANGE_PI_ONE,
+    ORANGE_PI_LITE,
+    ORANGE_PI_LITE
 )
 
 _CORAL_IDS = (
@@ -449,8 +457,15 @@ class Board:
             return ORANGE_PI_R1
         if board_value == "orangepizero":
             return ORANGE_PI_ZERO
+        if board_value == "oragepione":
+            return ORANGE_PI_ONE
+        if board_value == "orangepilite":
+            return ORANGE_PI_LITE
+        if board_value == "orangepipcplus":
+            return ORANGE_PI_PC_PLUS
         if board_value == "pinebook-a64":
             return PINEBOOK
+
         return None
 
     def _sama5_id(self):

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -448,6 +448,7 @@ class Board:
         return None
     # pylint: enable=no-self-use
 
+    # pylint: disable=too-many-return-statements
     def _armbian_id(self):
         """Check whether the current board is an OrangePi PC or OrangePI R1."""
         board_value = self.detector.get_armbian_release_field('BOARD')
@@ -467,6 +468,7 @@ class Board:
             return PINEBOOK
 
         return None
+    # pylint: enable=too-many-return-statements
 
     def _sama5_id(self):
         """Check what type sama5 board."""

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -457,7 +457,7 @@ class Board:
             return ORANGE_PI_R1
         if board_value == "orangepizero":
             return ORANGE_PI_ZERO
-        if board_value == "oragepione":
+        if board_value == "orangepione":
             return ORANGE_PI_ONE
         if board_value == "orangepilite":
             return ORANGE_PI_LITE


### PR DESCRIPTION
Hey @makermelissa,

In the mean while I'm also doing this PR to add more Orange Pi board.

This is the output from the Orange Pi One:
```console
root@orangepione:~/workspace/Adafruit_Python_PlatformDetect# python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import adafruit_platformdetect
>>> detector = adafruit_platformdetect.Detector()
>>> detector.board.id
'ORANGE_PI_ONE'
>>> detector.chip.id
'SUN8I'
>>> detector.board.
detector.board.any_96boards             detector.board.any_giant_board          detector.board.any_orange_pi            detector.board.any_raspberry_pi_cm      detector.board.ftdi_ft232h
detector.board.any_beaglebone           detector.board.any_jetson_board         detector.board.any_pine64_board         detector.board.any_sifive_board         detector.board.id
detector.board.any_coral_board          detector.board.any_odroid_40_pin        detector.board.any_raspberry_pi         detector.board.binho_nova               detector.board.microchip_mcp2221
detector.board.any_embedded_linux       detector.board.any_onion_omega_board    detector.board.any_raspberry_pi_40_pin  detector.board.detector                 
>>> detector.board.any_orange_pi
True
>>> detector.board.any_embedded_linux
True
>>>

I'll be testing the other boards soon.

Regards.
```