### PR TITLE
Addition of Orange Pi Plus 2E

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -36,6 +36,7 @@ ORANGE_PI_ZERO              = "ORANGE_PI_ZERO"
 ORANGE_PI_ONE               = "ORANGE_PI_ONE"
 ORANGE_PI_LITE              = "ORANGE_PI_LITE"
 ORANGE_PI_PC_PLUS           = "ORANGE_PI_PC_PLUS"
+ORANGE_PI_PLUS_2E           = "ORANGE_PI_PLUS_2E"
 
 # NVIDIA Jetson boards
 JETSON_TX1                  = 'JETSON_TX1'
@@ -93,7 +94,8 @@ _ORANGE_PI_IDS = (
     ORANGE_PI_ZERO,
     ORANGE_PI_ONE,
     ORANGE_PI_LITE,
-    ORANGE_PI_LITE
+    ORANGE_PI_PC_PLUS,
+    ORANGE_PI_PLUS_2E,
 )
 
 _CORAL_IDS = (
@@ -462,6 +464,8 @@ class Board:
             return ORANGE_PI_ONE
         if board_value == "orangepilite":
             return ORANGE_PI_LITE
+        if board_value == "orangepiplus2e":
+            return ORANGE_PI_PLUS_2E
         if board_value == "orangepipcplus":
             return ORANGE_PI_PC_PLUS
         if board_value == "pinebook-a64":


### PR DESCRIPTION
Hey! Fixing some minor issues on Orange Pi Ids and adding the Orange Pi +2E

```console
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import adafruit_platformdetect
>>> detector = adafruit_platformdetect.Detector()
>>> detector.board.id
'ORANGE_PI_PLUS_2E'
>>> detector.chip.id
'SUN8I'
>>> detector.board.any_embedded_linux
True
>>> detector.board.any_orange_pi
True
>>>
```