### PR TITLE
Huge GreatFET detection speedup

### DIFF
--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -88,17 +88,14 @@ class Chip:
                 + "set, but no MCP2221 device found"
             )
         if os.environ.get("BLINKA_GREATFET"):
-            from greatfet import GreatFET
-            from greatfet.errors import DeviceNotFoundError
+            import usb
 
-            try:
-                _ = GreatFET()
+            if usb.core.find(idVendor=0x1d50, idProduct=0x60e6) is not None:
                 return chips.LPC4330
-            except DeviceNotFoundError():
-                raise RuntimeError(
-                    "BLINKA_GREATFET environment variable "
-                    + "set, but no GreatFET device found"
-                )
+            raise RuntimeError(
+                "BLINKA_GREATFET environment variable "
+                + "set, but no GreatFET device found"
+            )
         if os.environ.get("BLINKA_NOVA"):
             return chips.BINHO
 

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -90,7 +90,7 @@ class Chip:
         if os.environ.get("BLINKA_GREATFET"):
             import usb
 
-            if usb.core.find(idVendor=0x1d50, idProduct=0x60e6) is not None:
+            if usb.core.find(idVendor=0x1D50, idProduct=0x60E6) is not None:
                 return chips.LPC4330
             raise RuntimeError(
                 "BLINKA_GREATFET environment variable "


### PR DESCRIPTION
Digging into the GreatFET library, I streamlined this. It was taking about 15 seconds to run detect and crashing with a memory error. This makes it instant and fixes the memory error. The only downside is because Great Scott Gadgets uses the same VID/PID for all their boards, and GSG board will be detected as the GreatFET One.