### PR TITLE
Fixed an issue where `__init__.check_dt_compatible_value` opened a file…

### DIFF
--- a/adafruit_platformdetect/__init__.py
+++ b/adafruit_platformdetect/__init__.py
@@ -62,8 +62,9 @@ class Detector:
         """
         # Match a value like 'qcom,apq8016-sbc':
         try:
-            if value in open("/proc/device-tree/compatible").read():
-                return True
+            with open("/proc/device-tree/compatible") as compatible:
+                if value in compatible.read():
+                    return True
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
… but did not close it and thus caused a memory leak and a `ResourceWarning`.

I also wrote this test program to verify that my change worked.  If it would be helpful, I can add it to the repo in an additional commit.

```python
#
# Run this test with `python3 -m unittest` in 
# `Adafruit_Python_PlatformDetect/adafruit_platformdetect`
#
import unittest
import warnings

from __init__ import Detector


class TestDetector(unittest.TestCase):

    def test_check_dt_compatible_value_closes_file(self):
        detector = Detector()
        with warnings.catch_warnings(record=True) as warning:
            warnings.simplefilter("default", category=ResourceWarning)
            detector.check_dt_compatible_value("test")
            self.assertEquals(len(warning), 0,
                              "The file `/proc/device-tree/compatible` "
                              "is not\nbeing closed and Detector is "
                              "leaking memory.")
```