### PR TITLE
Fix recursion loop in `__getattr__`

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -501,6 +501,6 @@ class Board:
         Detect whether the given attribute is the currently-detected board.  See list
         of constants at the top of this module for available options.
         """
-        if self.id == attr:
+        if attr != "id" and self.id == attr:
             return True
         return False

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -257,6 +257,6 @@ class Chip:
         Detect whether the given attribute is the currently-detected chip.  See
         list of constants at the top of this module for available options.
         """
-        if self.id == attr:
+        if attr != "id" and self.id == attr:
             return True
         return False


### PR DESCRIPTION
The overriden `__getattr` in `board.Board` and `chip.Chip` may cause recursion errors. In theory this shouldn't happen, based on what the [Python docs](https://docs.python.org/3.8/reference/datamodel.html#customizing-attribute-access) tell us.

This PR simply checks that the attribute being asked for isn't `id` which those functions call, which then creates an infinite loop.

Fixes #96