### PR TITLE
Fix generic amd not returning a chip

### DIFF
--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -161,6 +161,9 @@ class Chip:
                     linux_id = chips.RYZEN_V1202B
                 if "RYZEN EMBEDDED V1605B" in model_name:
                     linux_id = chips.RYZEN_V1605B
+                else:
+                    linux_id = chips.GENERIC_X86
+            ##            print("linux_id = ", linux_id)
             elif vendor_id == "GenuineIntel":
                 model_name = self.detector.get_cpuinfo_field("model name").upper()
                 ##                print('model_name =', model_name)


### PR DESCRIPTION
An x86/x64 device (ie Desktop) with an AMD processor will not return a chip type, which causes a recursion error in `chip.Chip.__getattr__`. This simply adds the possibility of returning `GENERIC_LINUX_PC` when no other AMD chip matches.

Tested working on:
- VBox VM running Ubuntu 20.04 on AMD FX8320E
- Ubuntu 20.04 on Intel i5-3470
- Raspberry Pi 3B
- Orange Pi Zero LTS

Fixes #96