### PR TITLE
Fix documentation title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = "Adafruit Blinka Library"
+project = "Adafruit PlatformDetect Library"
 copyright = "2017 Adafruit Industries"
 author = "Brennen Bearnes"
 


### PR DESCRIPTION
Using the Blinka title is canibalizing page rank for the real Blinka library docs.