### PR TITLE
Fix None type not iterable issue on Github actions

### DIFF
--- a/adafruit_platformdetect/__init__.py
+++ b/adafruit_platformdetect/__init__.py
@@ -61,7 +61,8 @@ class Detector:
         otherwise False.
         """
         # Match a value like 'qcom,apq8016-sbc':
-        if value in self.get_device_compatible():
+        dt_compatible = self.get_device_compatible()
+        if dt_compatible and value in dt_compatible:
             return True
 
         return False


### PR DESCRIPTION
When `self.get_device_compatible()` returned None, the code failed (see https://github.com/adafruit/Adafruit_CircuitPython_PyPortal/runs/1723769481?check_suite_focus=true for example). This fixes it.