### PR TITLE
Add Revision ID for Pi CM4

### DIFF
--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -442,6 +442,7 @@ _PI_REV_CODES = {
     RASPBERRY_PI_CM4: (
         "a03140",
         "b03140",
+        "c03140",
     ),
 }
 


### PR DESCRIPTION
Raspberry Pi Compute Module 4, Wireless, 4GB, 16GB - CM4104016