### PR TITLE
Add rervision code for 8 GB CM4 Lite with WiFi

### DIFF
--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -428,7 +428,7 @@ _PI_REV_CODES = {
         "2c03112",
     ),
     RASPBERRY_PI_400: ("c03130",),
-    RASPBERRY_PI_CM4: ("a03140", "b03140", "c03140"),
+    RASPBERRY_PI_CM4: ("a03140", "b03140", "c03140","d03140"),
 }
 
 # Onion omega boards


### PR DESCRIPTION
Might be a good idea to eventually rework this by calculating a valid Pi revision via their revision scheme they started using since Pi2: https://github.com/raspberrypi/documentation/blob/master/hardware/raspberrypi/revision-codes/README.md