### PR TITLE
Move Generic X86 to bottom

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -77,8 +77,6 @@ class Board:
             board_id = self._beaglebone_id()
         elif chip_id == chips.DRA74X:
             board_id = self._bbai_id()
-        elif chip_id == chips.GENERIC_X86:
-            board_id = boards.GENERIC_LINUX_PC
         elif chip_id == chips.SUN8I:
             board_id = self._armbian_id() or self._allwinner_variants_id()
         elif chip_id == chips.SAMA5:
@@ -169,6 +167,8 @@ class Board:
             board_id = boards.QTPY_U2IF
         elif chip_id == chips.QT2040_TRINKEY_U2IF:
             board_id = boards.QT2040_TRINKEY_U2IF
+        elif chip_id == chips.GENERIC_X86:
+            board_id = boards.GENERIC_LINUX_PC
         self._board_id = board_id
         return board_id
 


### PR DESCRIPTION
On certain processors, Generic X86 is being detected before the MCP2221 and FT232H. This should fix it by checking the Generic X86 after those.