### PR TITLE
Pin PyLint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       # (e.g. - apt-get: gettext, etc; pip: circuitpython-build-tools, requirements.txt; etc.)
       run: |
         source actions-ci/install.sh
-    - name: Pip install pylint==2.7.1, black, & Sphinx
+    - name: Pip install pylint, black, & Sphinx
       run: |
         pip install --force-reinstall pylint==2.7.1 black Sphinx sphinx-rtd-theme
     - name: Library version


### PR DESCRIPTION
Pins PyLint to version 2.7.1 to match Adafruit_Blinka and the other CircuitPython libraries.