### PR TITLE
Add Banana Pi M2 Zero to any embedded linux detection

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -598,11 +598,11 @@ class Board:
     def any_stm32mp1(self):
         """Check whether the current board is any stm32mp1 board."""
         return self.id in boards._STM32MP1_IDS
-    
+
     @property
     def any_bananapi(self):
         """Check whether the current board is any BananaPi-family system."""
-        return self.id in boards._BANANA_PI_IDS 
+        return self.id in boards._BANANA_PI_IDS
 
     @property
     def any_embedded_linux(self):


### PR DESCRIPTION
Adding support for bananaPi M(P)2 Zero detection. When trying to initialise I2C for the BPI, busio.py from adafruit_blinka was always trying to import `adafruit_blinka.microcontroller.generic_micropython.i2c` which imported `machine` (not found by python). As the file `constants/boards.py` contained the BPI board I figured it should also be included in this file as "any embedded linux". This works for my BananaPi P2 Zero.