### PR TITLE
Support homebrew libusb on macOS

### DIFF
--- a/adafruit_platformdetect/__init__.py
+++ b/adafruit_platformdetect/__init__.py
@@ -5,11 +5,17 @@
 """
 Attempt to detect the current platform.
 """
+import os
 import re
+import sys
 from typing import Optional
+
 from .board import Board
 from .chip import Chip
 
+# Needed to find libs (like libusb) installed by homebrew on Apple Silicon
+if sys.platform == "darwin":
+    os.environ["DYLD_FALLBACK_LIBRARY_PATH"] = "/opt/homebrew/lib/"
 
 # Various methods here may retain state in future, so tell pylint not to worry
 # that they don't use self right now:


### PR DESCRIPTION
For macOS running on Apple Silicon, installing `libusb` via homebrew (`brew install libusb`) installs the libraries to `/opt/homebrew/lib/`.  Older versions of python (e.g. 3.7 installed via pyenv) won't be able to find the homebrew libusb libraries.  When trying to use a device like the [GreatFET One](https://circuitpython.org/blinka/greatfet_one/) that uses `pyusb`,  `bin/detect.py` will throw an error like this:

```
❯ bin/detect.py 
Traceback (most recent call last):
  File "bin/detect.py", line 35, in <module>
    print("Chip id: ", detector.chip.id)
  File "/Users/chris/Projects/Adafruit_Python_PlatformDetect/adafruit_platformdetect/chip.py", line 138, in id
    if usb.core.find(idVendor=0x1D50, idProduct=0x60E6) is not None:
  File "/Users/chris/.pyenv/versions/test-platformdetect/lib/python3.7/site-packages/usb/core.py", line 1309, in find
    raise NoBackendError('No backend available')
usb.core.NoBackendError: No backend available
```

This PR just adds the homebrew libusb path to the macOS DYLD fallback library search path:

```
❯ bin/detect.py 
Chip id:  LPC4330
Board id:  GREATFET_ONE
...
Is this an OS environment variable special case? True
```