### PR TITLE
add support for CM4 with 8GB ram

### DIFF
--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -489,7 +489,7 @@ _PI_REV_CODES = {
         "2c03112",
     ),
     RASPBERRY_PI_400: ("c03130", "c03131"),
-    RASPBERRY_PI_CM4: ("a03140", "b03140", "c03140", "d03140"),
+    RASPBERRY_PI_CM4: ("a03140", "b03140", "c03140", "d03140", "d03141"),
     RASPBERRY_PI_ZERO_2_W: ("902120", "2902120"),
 }
 


### PR DESCRIPTION
The revision number for CM4 with 8GB ram is d03141. Please consider adding it. 


```
pi@raspberry:~ $ cat /proc/cpuinfo
processor       : 0
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 2
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 3
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

Hardware        : BCM2835
Revision        : d03141
Serial          : 10000000afbf721a
Model           : Raspberry Pi Compute Module 4 Rev 1.1
```
