### PR TITLE
Update Readme: Requires Python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Dependencies
 =============
 This driver depends on:
 
-* Python 3.6 or higher
+* Python 3.7 or higher
 
 Installing from PyPI
 =====================


### PR DESCRIPTION
Since version 3.20.0, which added Type Annotations, this package actually requires Python 3.7, which is the first version that supports them. The Readme should be updated accordingly.