### PR TITLE
Add RASPBERRY_PI_4B rev code

### DIFF
--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -509,6 +509,7 @@ _PI_REV_CODES = {
         "2b03112",
         "1c03112",
         "2c03112",
+        "80c03114",
     ),
     RASPBERRY_PI_400: ("c03130", "c03131"),
     RASPBERRY_PI_CM4: (


### PR DESCRIPTION
These changes are due to the fact that we received a device with revision number `80c03114`. We are not sure if this is an error or if it is the correct number, but our board cannot be found

```bash
processor	: 0
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 1
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 2
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

processor	: 3
BogoMIPS	: 108.00
Features	: fp asimd evtstrm crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd08
CPU revision	: 3

Hardware	: BCM2835
Revision	: 80c03114
Serial		: 10000000f94d9d8c
Model		: Raspberry Pi 4 Model B Rev 1.4
```