### PR TITLE
Fix detection of Pine64 devices

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -452,14 +452,14 @@ class Board:
         """Try to detect the id for Pine64 board or device."""
         board_value = self.detector.get_device_model()
         board = None
-        if "pine64" in board_value.lower():
+        if "pinephone" in board_value.lower():
+            board = boards.PINEPHONE
+        elif "pine64" in board_value.lower():
             board = boards.PINE64
         elif "pine h64" in board_value.lower():
             board = boards.PINEH64
         elif "pinebook" in board_value.lower():
             board = boards.PINEBOOK
-        elif "pinephone" in board_value.lower():
-            board = boards.PINEPHONE
         elif "sopine" in board_value.lower():
             board = boards.SOPINE
         return board


### PR DESCRIPTION
Hi Adafruit devs :)

I'm working with a Pine64 Pinephone, and noticed that `PlatformDetect` was identifying my device as a `PINE64` single-board computer. I started looking into the logic and noticed a few things:
* There are constants defined for multiple Pine64 devices, including Pinephone, Pinebook, Pine64, PineH64, and Sopine.
* The logic in the detector reads the string from `/proc/device-tree/model` and sets the board id based on whether that string contains some substring.
* My Pinephone (running an Arch Linux distro, but also double checked this with the Manjaro distro it shipped with) has the model string `Pine64 PinePhone (1.2)`. The way the `if-elif` statement is structured caused the board id to always be `PINE64`. I changed the structure to work for my device, but my change will likely break this for a Pine64 SBC.

Perhaps someone could give me some ideas about how to redo the logic to be generic for all Pine64 device? It would be helpful to see the contents of `/proc/device-tree/model` for all the Pine64 devices that `PlatformDetect` supports. One idea might be to compare only on the second word of the model name.

Next up is PR `Blinka` to include the PinePhone. Thanks!