### PR TITLE
Adding NXP NavQPlus to detected boards 

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -418,6 +418,8 @@ class Board:
             return boards.MAAXBOARD
         if "Phanbell" in board_value:
             return boards.CORAL_EDGE_TPU_DEV
+        if "NXP i.MX8MPlus SOM " in board_value:
+            return boards.NXP_IMX8MPLUS_SOM
         return None
 
     def _imx6ull_id(self) -> Optional[str]:
@@ -798,6 +800,11 @@ class Board:
         return self.id in boards._LIBRE_COMPUTER_IDS
 
     @property
+    def any_nxp_navq_board(self) -> bool:
+        """Check whether the current board is any NXP NavQ board"""
+        return self.id in boards._NXP_SOM_IDS
+
+    @property
     def os_environ_board(self) -> bool:
         """Check whether the current board is an OS environment variable special case."""
 
@@ -851,7 +858,7 @@ class Board:
             yield self.any_pcduino_board
             yield self.any_libre_computer_board
             yield self.generic_linux
-
+            yield self.any_nxp_navq_board
         return any(condition for condition in lazily_generate_conditions())
 
     @property

--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -585,3 +585,11 @@ _LIBRE_COMPUTER_IDS = (
     AML_S905X_CC,
     ROC_RK3328_CC,
 )
+
+# NXP System on Module Computer boards
+NXP_IMX8MPLUS_SOM = "NXP_IMX8MPLUS_SOM"
+
+_NXP_SOM_IDS = (
+    NXP_IMX8MPLUS_SOM,
+)
+

--- a/bin/detect.py
+++ b/bin/detect.py
@@ -111,3 +111,6 @@ if detector.board.any_lubancat:
 
 if detector.board.any_siemens_simatic_iot2000:
     print("Siemens Simatic IOT2000 Gateway detected.")
+
+if detector.board.any_nxp_navq_board:
+    print("NXP NavQ board detected.")


### PR DESCRIPTION
Adding the NXP NavQPlus board: 
Board documentation available [here:](https://nxp.gitbook.io/8mpnavq/)
(Based on the the NXP i.MX 8M Plus SOC so the chip is already detected)


Future boards using the same SOC may need to edit the board name or detection line in bin/detect.py so it doesn't list it as an NXP NavQ based board

Tested on Ubuntu 22.04 built on top of NXP Yocto 5.15

Added for the Hovergames 3
Team McFly
2023
Instructions followed : https://learn.adafruit.com/adding-a-single-board-computer-to-platformdetect-for-blinka/overview
 Changes to be committed:
	modified:   adafruit_platformdetect/board.py
	modified:   adafruit_platformdetect/constants/boards.py
	modified:   bin/detect.py