### PR TITLE
Add Detection for AM625x SoC and BeaglePlay

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -186,7 +186,7 @@ class Board:
         elif chip_id == chips.GENERIC_X86:
             board_id = boards.GENERIC_LINUX_PC
         elif chip_id == chips.TDA4VM:
-            board_id =  self._beaglebone_id() or self._tisk_id()
+            board_id = self._beaglebone_id() or self._tisk_id()
         elif chip_id == chips.D1_RISCV:
             board_id = self._armbian_id()
         elif chip_id == chips.S905X:
@@ -273,7 +273,7 @@ class Board:
                     eeprom_bytes = eeprom.read(16)
             except FileNotFoundError:
                 try:
-                    #Special Case for AI64
+                    # Special Case for AI64
                     with open("/sys/bus/nvmem/devices/2-00500/nvmem", "rb") as eeprom:
                         eeprom_bytes = eeprom.read(16)
                 except FileNotFoundError:
@@ -286,7 +286,7 @@ class Board:
         # refer to GitHub issue #57 in this repo for more info
         if eeprom_bytes == b"\xaaU3\xeeA335BNLT\x1a\x00\x00\x00":
             return boards.BEAGLEBONE_GREEN
-        
+
         # BeaglePlay Special Condition
         # new Beagle EEPROM IDs are 24 Bit, so we need to verify full range
         if eeprom_bytes == b"\xaaU3\xee\x017\x00\x10.\x00BEAGLE":

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -276,7 +276,7 @@ class Board:
                     #Special Case for AI64
                     with open("/sys/bus/nvmem/devices/2-00500/nvmem", "rb") as eeprom:
                         eeprom_bytes = eeprom.read(16)
-                except:
+                except FileNotFoundError:
                     return None
 
         if eeprom_bytes[:4] != b"\xaaU3\xee":
@@ -294,8 +294,6 @@ class Board:
                 eeprom_bytes = eeprom.read(24)
             if eeprom_bytes == b"\xaaU3\xee\x017\x00\x10.\x00BEAGLEPLAY-A0-":
                 return boards.BEAGLE_PLAY
-            else:
-                return None
 
         id_string = eeprom_bytes[4:].decode("ascii")
         for model, bb_ids in boards._BEAGLEBONE_BOARD_IDS.items():

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -65,6 +65,8 @@ class Board:
             board_id = self._armbian_id() or self._allwinner_variants_id()
         elif chip_id == chips.BCM2XXX:
             board_id = self._pi_id()
+        elif chip_id == chips.AM625X:
+            board_id = self._beaglebone_id()
         elif chip_id == chips.AM33XX:
             board_id = self._beaglebone_id()
         elif chip_id == chips.AM65XX:
@@ -184,7 +186,7 @@ class Board:
         elif chip_id == chips.GENERIC_X86:
             board_id = boards.GENERIC_LINUX_PC
         elif chip_id == chips.TDA4VM:
-            board_id = self._tisk_id()
+            board_id =  self._beaglebone_id() or self._tisk_id()
         elif chip_id == chips.D1_RISCV:
             board_id = self._armbian_id()
         elif chip_id == chips.S905X:
@@ -270,7 +272,12 @@ class Board:
                 with open("/sys/bus/nvmem/devices/0-00501/nvmem", "rb") as eeprom:
                     eeprom_bytes = eeprom.read(16)
             except FileNotFoundError:
-                return None
+                try:
+                    #Special Case for AI64
+                    with open("/sys/bus/nvmem/devices/2-00500/nvmem", "rb") as eeprom:
+                        eeprom_bytes = eeprom.read(16)
+                except:
+                    return None
 
         if eeprom_bytes[:4] != b"\xaaU3\xee":
             return None
@@ -279,6 +286,16 @@ class Board:
         # refer to GitHub issue #57 in this repo for more info
         if eeprom_bytes == b"\xaaU3\xeeA335BNLT\x1a\x00\x00\x00":
             return boards.BEAGLEBONE_GREEN
+        
+        # BeaglePlay Special Condition
+        # new Beagle EEPROM IDs are 24 Bit, so we need to verify full range
+        if eeprom_bytes == b"\xaaU3\xee\x017\x00\x10.\x00BEAGLE":
+            with open("/sys/bus/nvmem/devices/0-00500/nvmem", "rb") as eeprom:
+                eeprom_bytes = eeprom.read(24)
+            if eeprom_bytes == b"\xaaU3\xee\x017\x00\x10.\x00BEAGLEPLAY-A0-":
+                return boards.BEAGLE_PLAY
+            else:
+                return None
 
         id_string = eeprom_bytes[4:].decode("ascii")
         for model, bb_ids in boards._BEAGLEBONE_BOARD_IDS.items():

--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -178,6 +178,8 @@ class Chip:
         # pylint: disable=too-many-branches,too-many-statements
         # pylint: disable=too-many-return-statements
         """Attempt to detect the CPU on a computer running the Linux kernel."""
+        if self.detector.check_dt_compatible_value("ti,am625"):
+            return chips.AM625X
         if self.detector.check_dt_compatible_value("ti,am654"):
             return chips.AM65XX
 

--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -384,14 +384,8 @@ _SIFIVE_IDS = (SIFIVE_UNLEASHED,)
 #   https://github.com/beagleboard/image-builder
 # Thanks to zmatt on freenode #beagle for pointers.
 _BEAGLEBONE_BOARD_IDS = {
-    BEAGLE_PLAY: 
-    (
-        ("A0", "7.BEAGLE")
-    ),
-    BEAGLEBONE_AI64: 
-    (
-        ("B0", "7.BBONEA")
-    ),
+    BEAGLE_PLAY: (("A0", "7.BEAGLE")),
+    BEAGLEBONE_AI64: (("B0", "7.BBONEA")),
     # Original bone/white:
     BEAGLEBONE: (
         ("A4", "A335BONE00A4"),

--- a/adafruit_platformdetect/constants/boards.py
+++ b/adafruit_platformdetect/constants/boards.py
@@ -4,6 +4,8 @@
 
 """Definition of boards and/or ids"""
 # Allow for aligned constant definitions:
+BEAGLE_PLAY = "BEAGLE_PLAY"
+BEAGLEBONE_AI64 = "BEAGLEBONE_AI64"
 BEAGLEBONE = "BEAGLEBONE"
 BEAGLEBONE_BLACK = "BEAGLEBONE_BLACK"
 BEAGLEBONE_BLUE = "BEAGLEBONE_BLUE"
@@ -352,6 +354,8 @@ _ODROID_40_PIN_IDS = (
 )
 
 _BEAGLEBONE_IDS = (
+    BEAGLE_PLAY,
+    BEAGLEBONE_AI64,
     BEAGLEBONE,
     BEAGLEBONE_BLACK,
     BEAGLEBONE_BLUE,
@@ -380,6 +384,14 @@ _SIFIVE_IDS = (SIFIVE_UNLEASHED,)
 #   https://github.com/beagleboard/image-builder
 # Thanks to zmatt on freenode #beagle for pointers.
 _BEAGLEBONE_BOARD_IDS = {
+    BEAGLE_PLAY: 
+    (
+        ("A0", "7.BEAGLE")
+    ),
+    BEAGLEBONE_AI64: 
+    (
+        ("B0", "7.BBONEA")
+    ),
     # Original bone/white:
     BEAGLEBONE: (
         ("A4", "A335BONE00A4"),

--- a/adafruit_platformdetect/constants/chips.py
+++ b/adafruit_platformdetect/constants/chips.py
@@ -5,6 +5,7 @@
 """Definition of chips."""
 A311D = "A311D"
 AM33XX = "AM33XX"
+AM625X = "AM625X"
 AM65XX = "AM65XX"
 DRA74X = "DRA74X"
 TDA4VM = "TDA4VM"


### PR DESCRIPTION
Added Beagle Play:
https://beagleboard.org/play 

It features a Texas Instruments Sitara AM6254 MPU:
https://www.ti.com/product/AM625 

Please note Beagle EEPROM IDs are now 24 Bit and changed format as of AI64 and Beagle Play so had to add some more conditions to read the full 24 bits for Beagle Play.
See the updated: https://github.com/beagleboard/image-builder

This also includes some preliminary stuff for BeagleBone AI64 (TDA4VM /J721e). Will send second patch for that, need to patch DTB to make EEPROM readable within Linux on that first, for now just piggybacked off the SK EVM so it checks if it's a Beagle first. 