### PR TITLE
Fix detection for Orange Pi Zero 2 on Debian

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -607,8 +607,7 @@ class Board:
         if "nanopi" in board_value:
             if "neo" in board_value and "SUN8I" in chip_id:
                 board = boards.NANOPI_NEO_AIR
-            # TODO: Add other specifc board contexts here
-        elif "orange pi" in board_value:
+        elif any(x in board_value for x in ("orange pi", "orangepi")):
             if "zero" in board_value:
                 if "H5" in chip_id:
                     board = boards.ORANGE_PI_ZERO_PLUS_2H5


### PR DESCRIPTION
This fixes an issue where some OS like Debian check for "orangepi" rather than "orange pi".