### PR TITLE
Improve rpi_info script to run interactively

### DIFF
--- a/bin/rpi_info.py
+++ b/bin/rpi_info.py
@@ -23,49 +23,69 @@ Implementation Notes
 """
 
 import sys
+import argparse
 import adafruit_platformdetect
 from adafruit_platformdetect.revcodes import PiDecoder
 
 detector = adafruit_platformdetect.Detector()
-pi_rev_code = detector.board._pi_rev_code()  # pylint: disable=protected-access
-
-if pi_rev_code is None:
-    print("Raspberry Pi not detected. Using interactive mode")
-    pi_rev_code = input("Enter a Raspberry Pi revision code (e.g. d03114 or 000f): ")
-
-try:
-    decoder = PiDecoder(pi_rev_code)
-except ValueError as e:
-    print("Invalid revision code. It should be a hexadecimal value.")
-    sys.exit(1)
-
-if not decoder.is_valid_code():
-    print(
-        "Code is invalid. This rev code includes at least one "
-        "value that is outside of the expected range."
-    )
-    sys.exit(1)
+parser = argparse.ArgumentParser()
 
 
 def print_property(label, value):
-    "Format and print a property"
+    """Format and print a property"""
     print(f"{label}: {value}")
 
 
-if decoder.is_new_format():
-    print_property("Overvoltage", decoder.overvoltage)
-    print_property("OTP Program", decoder.otp_program)
-    print_property("OTP Read", decoder.otp_read)
-    print_property("Warranty bit", decoder.warranty_bit)
-    print_property("New flag", decoder.rev_style)
-    print_property("Memory size", decoder.memory_size)
-    print_property("Manufacturer", decoder.manufacturer)
-    print_property("Processor", decoder.processor)
-    print_property("Type", decoder.type)
-    print_property("Revision", decoder.revision)
-else:
-    print_property("Warranty bit", decoder.warranty_bit)
-    print_property("Model", decoder.type)
-    print_property("Revision", decoder.revision)
-    print_property("RAM", decoder.memory_size)
-    print_property("Manufacturer", decoder.manufacturer)
+def main(interactive):
+    """Run the program"""
+    pi_rev_code = detector.board._pi_rev_code()  # pylint: disable=protected-access
+
+    if pi_rev_code is None:
+        print("Raspberry Pi not detected. Using interactive mode")
+
+    if pi_rev_code is None or interactive:
+        pi_rev_code = input(
+            "Enter a Raspberry Pi revision code (e.g. d03114 or 000f): "
+        )
+
+    print_property("Revision Code", pi_rev_code)
+
+    try:
+        decoder = PiDecoder(pi_rev_code)
+    except ValueError:
+        print("Invalid revision code. It should be a hexadecimal value.")
+        sys.exit(1)
+
+    if not decoder.is_valid_code():
+        print(
+            "Code is invalid. This rev code includes at least one "
+            "value that is outside of the expected range."
+        )
+        sys.exit(1)
+
+    if decoder.is_new_format():
+        print_property("Overvoltage", decoder.overvoltage)
+        print_property("OTP Program", decoder.otp_program)
+        print_property("OTP Read", decoder.otp_read)
+        print_property("Warranty bit", decoder.warranty_bit)
+        print_property("New flag", decoder.rev_style)
+        print_property("Memory size", decoder.memory_size)
+        print_property("Manufacturer", decoder.manufacturer)
+        print_property("Processor", decoder.processor)
+        print_property("Type", decoder.type)
+        print_property("Revision", decoder.revision)
+    else:
+        print_property("Warranty bit", decoder.warranty_bit)
+        print_property("Model", decoder.type)
+        print_property("Revision", decoder.revision)
+        print_property("RAM", decoder.memory_size)
+        print_property("Manufacturer", decoder.manufacturer)
+
+
+# Main function
+if __name__ == "__main__":
+    parser.add_argument(
+        "-i", "--interactive", help="Interactive Mode", action="store_true"
+    )
+    args = parser.parse_args()
+    main(args.interactive)


### PR DESCRIPTION
I wanted to run this on a Raspberry Pi, but allow entering a different rev code manually. I added the ability to pass an argument to at the command line to do this. By using argparse, no external dependencies are needed.