### PR TITLE
Fix failing docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,12 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.7"
+
 python:
-  version: "3.7"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt


### PR DESCRIPTION
Just like in https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/113, this fixes the failing docs.