### PR TITLE
Remove Build Assets which is causing PRs to fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,13 +48,6 @@ jobs:
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
-    - name: Build assets
-      run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
-    - name: Archive bundles
-      uses: actions/upload-artifact@v2
-      with:
-        name: bundles
-        path: ${{ github.workspace }}/bundles/
     - name: Build docs
       working-directory: docs
       run: sphinx-build -E -W -b html . _build/html


### PR DESCRIPTION
Fixes #338. The Build Bundles is causing a failure and is not present in other non-CircuitPython repos, so it doesn't seem necessary here.