### PR TITLE
Added detection for LeMaker Banana Pro running Debian Bookworm (12.4)

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -703,6 +703,9 @@ class Board:
         board_value = board_value.lower()
         chip_id = self.detector.chip.id
 
+        if "banana pro" in board_value:
+            board = boards.LEMAKER_BANANA_PRO
+
         if "banana pi m2 berry" in board_value:
             board = boards.BANANA_PI_M2_BERRY
 

--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -404,8 +404,6 @@ class Board:
             board = boards.BANANA_PI_M2_BERRY
         elif board_value == "bananapim5":
             board = boards.BANANA_PI_M5
-        elif board_value == "bananapipro":
-            board = boards.LEMAKER_BANANA_PRO
         elif board_value == "orangepizeroplus2-h5":
             board = boards.ORANGE_PI_ZERO_PLUS_2H5
         elif board_value == "orangepizeroplus":


### PR DESCRIPTION
It looks like Banana Pro was previously supported, but for Armbian in particular. It looked like `_allwinner_variants_id` was the right place for adding the detection, so I did.

This shows the SBC host I'm using:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % uname -a
Linux bpro 6.1.0-17-armmp-lpae #1 SMP Debian 6.1.69-1 (2023-12-30) armv7l GNU/Linux
```
Here's the data I used for the board detection:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % cat /proc/device-tree/model
LeMaker Banana Pro%
```
Here's my dev environment:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % pip list
Package                 Version      Editable project location
----------------------- ------------ ------------------------------------------------
Adafruit-PlatformDetect 0.0.0+auto.0 /home/mstoops/git/Adafruit_Python_PlatformDetect
astroid                 3.0.2
black                   24.1.1
click                   8.1.7
dill                    0.3.8
isort                   5.13.2
mccabe                  0.7.0
mypy-extensions         1.0.0
packaging               23.2
pathspec                0.12.1
pip                     23.0.1
platformdirs            4.1.0
pylint                  3.0.3
setuptools              66.1.1
tomlkit                 0.12.3
wheel                   0.38.4
```
pylint results:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % python -m pylint adafruit_platformdetect

------------------------------------
Your code has been rated at 10.00/10
```
Black results:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % python -m black adafruit_platformdetect
All done! ✨ 🍰 ✨
7 files left unchanged.
```
`detect.py` after my changes:
```
mstoops@bpro ~/git/Adafruit_Python_PlatformDetect
 % python ./bin/detect.py
Board Detection Test

Check that the Chip and Board IDs match your board and that this it is
correctly detecting whether or not it is a Linux board.

Chip id:  A20
Board id:  LEMAKER_BANANA_PRO

Linux Detection
---------------
Is this an embedded Linux system? True

Raspberry Pi Boards
-------------------
Is this a Pi 3B+? False
Is this a Pi 4B? False
Is this a 40-pin Raspberry Pi? False
Is this a Raspberry Pi Compute Module? False

Other Boards
-------------------
Is this a Siemens Simatic IOT2000 Gateway? False
Is this a 96boards board? False
Is this a BeagleBone board? False
Is this a Giant board? False
Is this a Coral Dev board? False
Is this a MaaXBoard? False
Is this a SiFive board?  False
Is this a PYNQ board? False
Is this a Rock Pi board? False
Is this a NanoPi board? False
Is this a Khadas VIM3 board? False
Is this a Clockwork Pi board? False
Is this a Seeed Board? False
Is this a UDOO board? False
Is this an ASUS Tinker board? False
Is this an STM32MP1 board? False
Is this a MilkV board? False
Is this a generic Linux PC? False
Is this an OS environment variable special case? False
LeMaker board detected.
```
Previously, detect.py crashed as a result of board ID being `None`. I didn't grab a screenshot.