### PR TITLE
Fix Orange Pi detection on non-Armbian systems (Debian)

### DIFF
--- a/adafruit_platformdetect/board.py
+++ b/adafruit_platformdetect/board.py
@@ -157,7 +157,10 @@ class Board:
             board_id = self._pine64_id()
         elif chip_id == chips.H6:
             board_id = (
-                self._pine64_id() or self._armbian_id() or self._repka_variants_id()
+                self._pine64_id()
+                or self._armbian_id()
+                or self._orange_pi_id()
+                or self._repka_variants_id()
             )
         elif chip_id == chips.H5:
             board_id = (
@@ -174,7 +177,11 @@ class Board:
                 or self._orange_pi_id()
             )
         elif chip_id == chips.H616:
-            board_id = self._armbian_id() or self._allwinner_variants_id()
+            board_id = (
+                self._armbian_id()
+                or self._allwinner_variants_id()
+                or self._orange_pi_id()
+            )
         elif chip_id == chips.A33:
             board_id = self._clockwork_pi_id()
         elif chip_id == chips.K1:
@@ -569,8 +576,14 @@ class Board:
             return boards.ORANGE_PI_5
         if "Orange Pi 3B" in board_value:
             return boards.ORANGE_PI_3B
-        if "OrangePi Zero 2W" in board_value:
+        if "OrangePi Zero 2W" in board_value or "Orange Pi Zero 2W" in board_value:
             return boards.ORANGE_PI_ZERO_2W
+        if "OrangePi Zero2" in board_value or "Orange Pi Zero 2" in board_value:
+            return boards.ORANGE_PI_ZERO_2
+        if "OrangePi Zero3" in board_value or "Orange Pi Zero 3" in board_value:
+            return boards.ORANGE_PI_ZERO_3
+        if "Orange Pi 3 LTS" in board_value or "OrangePi 3 LTS" in board_value:
+            return boards.ORANGE_PI_3_LTS
         return None
 
     # pylint: enable=too-many-return-statements


### PR DESCRIPTION
### Summary

Fixes #285 — Orange Pi boards (Zero 2, Zero 3, 3 LTS) were not detected on Debian and other non-Armbian distributions because the detection path relied on `_armbian_id()` which reads `/etc/armbian-release` (not present on Debian).

### Changes

**1. Add `_orange_pi_id()` to H616 and H6 chip detection paths**

The H618 path already included `_orange_pi_id()` as a fallback, but H616 (used by Orange Pi Zero 2) and H6 (used by Orange Pi 3 LTS) did not. Now all three share the same fallback chain.

**2. Expand `_orange_pi_id()` with additional model strings**

Added detection for device-tree model strings (`/proc/device-tree/model`) used by non-Armbian OSes:

| Model String Variants | Board Constant |
|---|---|
| `OrangePi Zero2`, `Orange Pi Zero 2` | `ORANGE_PI_ZERO_2` |
| `OrangePi Zero3`, `Orange Pi Zero 3` | `ORANGE_PI_ZERO_3` |
| `Orange Pi Zero 2W` (space variant) | `ORANGE_PI_ZERO_2W` |
| `Orange Pi 3 LTS`, `OrangePi 3 LTS` | `ORANGE_PI_3_LTS` |

The ordering ensures the more specific `Zero 2W` match is checked before the broader `Zero 2` match.