### PR TITLE
Bump max-module-lines from 1000 to 2000

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -223,7 +223,7 @@ indent-string='    '
 max-line-length=100
 
 # Maximum number of lines in a module
-max-module-lines=1000
+max-module-lines=2000
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.


### PR DESCRIPTION
board.py is already at 1461 lines and growing as new boards are added. The 1000-line limit causes build failures when adding new board support.

Bumping to 2000 provides headroom until the board detection logic can be refactored into a data-driven approach (similar to Adafruit_Blinka#1040).

Fixes #296