### PR TITLE
Fix chip detection failure on Alpine Linux and other non-standard distros

### DIFF
--- a/adafruit_platformdetect/chip.py
+++ b/adafruit_platformdetect/chip.py
@@ -363,6 +363,9 @@ class Chip:
         if self.detector.check_dt_compatible_value("particle,tachyon"):
             return chips.QCM6490
 
+        if self.detector.check_dt_compatible_value("brcm,bcm2"):
+            return chips.BCM2XXX
+
         linux_id = None
         hardware = self.detector.get_cpuinfo_field("Hardware")
 
@@ -446,9 +449,12 @@ class Chip:
             # convert it to a list and let the remaining
             # conditions attempt.
             if not linux_id:
-                hardware = [
-                    entry.replace("\x00", "") for entry in compatible.split(",")
-                ]
+                if compatible:
+                    hardware = [
+                        entry.replace("\x00", "") for entry in compatible.split(",")
+                    ]
+                else:
+                    hardware = []
 
         if not linux_id:
             if "AM33XX" in hardware:
@@ -499,7 +505,7 @@ class Chip:
         list of constants at the top of this module for available options.
         """
         if attr == "id":
-            raise AttributeError()  # Avoid infinite recursion
+            raise AttributeError("id")  # Avoid infinite recursion
         if self.id == attr:
             return True
         return False


### PR DESCRIPTION
## Problem

On Alpine Linux (aarch64), `detector.chip.id` raises a bare `AttributeError` on Raspberry Pi boards (#342). This happens because:

1. `/proc/cpuinfo` on Alpine aarch64 doesn't include a `Hardware` field
2. There's no device-tree compatible check for Broadcom BCM chips in `_linux_id()`
3. When both `hardware` and `compatible` are `None`, `compatible.split(',')` crashes with `AttributeError`, which gets silently swallowed by `__getattr__` and surfaces as a confusing bare `AttributeError()`

## Fix

Three changes in `chip.py`:

1. **Add early device-tree check for BCM chips** — matches `brcm,bcm2` in `/proc/device-tree/compatible`, which is present on all Raspberry Pi boards regardless of distro. This is consistent with how other chip families (TI, Allwinner, Rockchip, etc.) are already detected via device-tree.

2. **Guard against NoneType crash** — if `compatible` is `None`, use an empty list instead of crashing on `.split()`.

3. **Improve `__getattr__` error message** — include the attribute name (`"id"`) so the error is actually debuggable.

Fixes #342